### PR TITLE
Update Process section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ All scripts, docs and other supplimentary files should go to `dev-riscv` directo
 
 ### Participiants
 
-Small changes (docs, typos, ...) may go directly into `riscv` branch.
+Small changes (typos, build fixes, ...) may go directly into `riscv` branch.
+Small one is usually so insignificant, such you think no-one interested to get notified about. 
+When in doubt, consider non-small.
 
 Significant contributions should be proposed as Pull Requiest:
  1. changes should be pushed to a feature branch of this repo (there is no need to use Github forks)


### PR DESCRIPTION
Hi

I was surprised to see github doesn't send notification on just pushes. And the only option is to setup at most two email addresses for that. This means everything that was directly pushed to `riscv` went unnoticed until accidentally found in the code. 

I'm going to change a small definition. This would make extra steps to contribute, but it's simple and anyone would get notified about changes. 