### PR TITLE
Add scripts to run docker and build jdk

### DIFF
--- a/dev-riscv/scripts/configure.sh
+++ b/dev-riscv/scripts/configure.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+OPTIND=1
+
+variants=core
+level=release
+
+while getopts "hv:l:" opt; do
+    case "$opt" in
+    h)
+        echo "usage: configure.sh [-h] [-v jvm-variants] [-l debug-level]"
+        echo "       -h show help"
+        echo "       -v set --with-jvm-variants flag (server, client, minimal, core, zero, zeroshark, custom). default is core"
+        echo "       -l set --with-debug-level flag (release, fastdebug, slowdebug, optimized). default is release"
+        exit 0
+        ;;
+    v)  variants=$OPTARG
+        ;;
+    l)  level=$OPTARG
+        ;;
+    esac
+done
+
+bash configure \
+    --with-jvm-variants=$variants \
+    --with-debug-level=$level \
+    --with-native-debug-symbols=internal \
+    --disable-warnings-as-errors \
+    --openjdk-target=riscv64-unknown-linux-gnu \
+    --with-sysroot=/opt/riscv/sysroot \
+    --x-includes=/opt/riscv/sysroot/usr/include \
+    --x-libraries=/opt/riscv/sysroot/usr/lib

--- a/dev-riscv/scripts/configure.sh
+++ b/dev-riscv/scripts/configure.sh
@@ -8,7 +8,7 @@ level=release
 while getopts "hv:l:" opt; do
     case "$opt" in
     h)
-        echo "usage: configure.sh [-h] [-v jvm-variants] [-l debug-level]"
+        echo "usage: $0 [-h] [-v jvm-variants] [-l debug-level]"
         echo "       -h show help"
         echo "       -v set --with-jvm-variants flag (server, client, minimal, core, zero, zeroshark, custom). default is core"
         echo "       -l set --with-debug-level flag (release, fastdebug, slowdebug, optimized). default is release"
@@ -20,6 +20,8 @@ while getopts "hv:l:" opt; do
         ;;
     esac
 done
+
+cd /jdk-riscv
 
 bash configure \
     --with-jvm-variants=$variants \

--- a/dev-riscv/scripts/make.sh
+++ b/dev-riscv/scripts/make.sh
@@ -8,7 +8,7 @@ level=release
 while getopts "hv:l:" opt; do
     case "$opt" in
     h)
-        echo "usage: make.sh [-h] [-v variant] [-l debug-level]"
+        echo "usage: $0 [-h] [-v variant] [-l debug-level]"
         echo "       -h show help"
         echo "       -v choose jvm-variant (server, client, minimal, core, zero, zeroshark, custom). default is core"
         echo "       -l choose debug level (release, fastdebug, slowdebug, optimized). default is release"
@@ -20,5 +20,7 @@ while getopts "hv:l:" opt; do
         ;;
     esac
 done
+
+cd /jdk-riscv
 
 make CONF=linux-riscv64-$variant-$level

--- a/dev-riscv/scripts/make.sh
+++ b/dev-riscv/scripts/make.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+OPTIND=1
+
+variant=core
+level=release
+
+while getopts "hv:l:" opt; do
+    case "$opt" in
+    h)
+        echo "usage: make.sh [-h] [-v variant] [-l debug-level]"
+        echo "       -h show help"
+        echo "       -v choose jvm-variant (server, client, minimal, core, zero, zeroshark, custom). default is core"
+        echo "       -l choose debug level (release, fastdebug, slowdebug, optimized). default is release"
+        exit 0
+        ;;
+    v)  variant=$OPTARG
+        ;;
+    l)  level=$OPTARG
+        ;;
+    esac
+done
+
+make CONF=linux-riscv64-$variant-$level

--- a/dev-riscv/scripts/run_qemu.sh
+++ b/dev-riscv/scripts/run_qemu.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+docker run --rm -it \
+    -v "$(pwd)":/jdk-riscv \
+    -e LD_LIBRARY_PATH=/jdk-riscv/riscv-sysroot/usr/lib/ \
+    --network host \
+    azulresearch/riscv-emu-user

--- a/dev-riscv/scripts/run_qemu.sh
+++ b/dev-riscv/scripts/run_qemu.sh
@@ -1,7 +1,31 @@
 #!/bin/bash
 
+if [ "$#" -gt 2 ]; then
+	echo "usage: $0 [path/to/sysroot [path/to/jdk-riscv]]"	
+	exit 1
+fi
+
+sysroot_path="$(pwd)/riscv-sysroot"
+jdk_riscv_path="$(pwd)"
+
+if [ "$#" -gt 0 ]; then
+	case $1 in
+  		/*) sysroot_path="$1" ;;
+  		*) 	sysroot_path="$(pwd)/$1" ;;
+	esac
+fi
+
+if [ "$#" -gt 1 ]; then
+	case $2 in
+  		/*) jdk_riscv_path="$2" ;;
+  		*) 	jdk_riscv_path="$(pwd)/$2" ;;
+	esac
+fi
+
 docker run --rm -it \
-    -v "$(pwd)":/jdk-riscv \
-    -e LD_LIBRARY_PATH=/jdk-riscv/riscv-sysroot/usr/lib/ \
+    -v "$jdk_riscv_path":/jdk-riscv \
+    -v "$sysroot_path":/opt/riscv/sysroot \
+    -e LD_LIBRARY_PATH=/opt/riscv/sysroot/usr/lib/ \
     --network host \
     azulresearch/riscv-emu-user
+ 

--- a/dev-riscv/scripts/run_toolchain.sh
+++ b/dev-riscv/scripts/run_toolchain.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm -it -v "$(pwd)":/jdk-riscv --network host tsarn/riscv-toolchain

--- a/dev-riscv/scripts/run_toolchain.sh
+++ b/dev-riscv/scripts/run_toolchain.sh
@@ -1,3 +1,17 @@
 #!/bin/bash
 
-docker run --rm -it -v "$(pwd)":/jdk-riscv --network host tsarn/riscv-toolchain
+if [ "$#" -gt 1 ]; then
+	echo "usage: $0 [path/to/jdk-riscv]"
+	exit 1
+fi
+
+jdk_riscv_path="$(pwd)"
+
+if [ "$#" -eq 1 ]; then
+	case $1 in
+  		/*) jdk_riscv_path="$1" ;;
+  		*) 	jdk_riscv_path="$(pwd)/$1" ;;
+	esac
+fi
+
+docker run --rm -it -v "$jdk_riscv_path":/jdk-riscv --network host tsarn/riscv-toolchain


### PR DESCRIPTION
Here are some scripts that automate some frequent actions. They all must be executed in the root repo directory.

These run the corresponding docker images:
```
dev-riscv/scripts/run_toolchain.sh
dev-riscv/scripts/run_qemu.sh
```

These configure and run build. They have the following parameters:
* **-h** show help
* **-v** set --with-jvm-variants flag
* **-l** set --with-debug-level flag
 ```
dev-riscv/scripts/configure.sh
dev-riscv/scripts/make.sh
```

Any critique and improvements are welcome :)